### PR TITLE
fix for pt-BR

### DIFF
--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -12,13 +12,12 @@ const languages: any = {
   fr: fr,
   es: es,
   de: de,
-  pt_BR: pt_BR,
+  'pt-BR': pt_BR,
 };
 
 export function localize(string: string, search = "", replace = ""): string {
   const lang = (localStorage.getItem("selectedLanguage") || "en")
-    .replace(/['"]+/g, "")
-    .replace("-", "_");
+    .replace(/['"]+/g, "");
 
   let translated: string;
 


### PR DESCRIPTION
pt_BR changed to 'pt-BR' (my mistake)
replace "-" with an "_" removed (don't know exactly why it was replacing, but removing it worked).
clearing the android app cache (settings>mobile app>debug>clear frontend cache) didn't work, but somehow changing the language to another one and then returning to portuguese worked.